### PR TITLE
Improved requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ django-bootstrap-form==3.1
 django-debug-toolbar==1.2.2
 django-taggit==0.12.2
 django-uuidfield==0.5.0
-psycopg2==2.5.4
 pytz==2014.10
 requests==2.5.1
+
+# Uncomment if you use postgres
+#psycopg2==2.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
-Django==1.7.2
-django-allauth==0.19.0
-django-bootstrap-form==3.1
-django-debug-toolbar==1.2.2
-django-taggit==0.12.2
-django-uuidfield==0.5.0
-pytz==2014.10
-requests==2.5.1
+## Django related requirements
+Django >= 1.7.2
+django-allauth >= 0.19.0
+django-bootstrap-form >= 3.1
+django-debug-toolbar >= 1.2.2
+django-taggit >= 0.12.2
+django-uuidfield >= 0.5.0
 
-# Uncomment if you use postgres
-#psycopg2==2.5.4
+## Postgresql specific requirements
+# uncomment if you use postgres
+#psycopg2 >= 2.5.4
+
+## Other requirements
+pytz >= 2014.10
+requests >= 2.5.1


### PR DESCRIPTION
- Removed an implicit requirement for postgresql-dev libs by uncommenting psycopg2 - making it optional instead.
- == should only be used when there is a good reason for wanting a specific distribution number, changed it to >= everywhere.
- Rearranged the packages and divided them into sections so that the file is more manageable, hopefully also in the future.
