### PR TITLE
fix value check on ignorename in Analyze(...)

### DIFF
--- a/src/ssllabs/api.py
+++ b/src/ssllabs/api.py
@@ -142,7 +142,7 @@ def Analyze(host, publish=None, ignorename=None, startNew=None, fromCache=None, 
     
     ### ignorename parameter, should be "on" or "off"
     if ignorename:
-        if publish != "on" and publish != "off":
+        if ignorename != "on" and ignorename != "off":
             # invalid option
             print "invalid publish option"
             return False


### PR DESCRIPTION
Fixes what appears to be a copy-pasta mistake where value of `publish` is validated (like above) while `ignorename` is used.
